### PR TITLE
fix Bollinger Bands calculation

### DIFF
--- a/R_Stock/BasicStockAnalysis.R
+++ b/R_Stock/BasicStockAnalysis.R
@@ -72,10 +72,13 @@ MACD <- rollapply(AAPL$AAPL.Adjusted, width = n2,
 
 # Bollinger Bands
 n <- 20
+meanseries <- rollapply(AAPL$AAPL.Adjusted, width = n,
+                       FUN = mean, by.column = TRUE,
+                       fill = NA, align = "right")
 BB <- rollapply(AAPL$AAPL.Adjusted, width = n,
                 FUN = sd, by.column = TRUE,
                 fill = NA, align = "right")
 upperseries <- meanseries + 2 * BB
-lowerseries <- meanseries + 2 - BB
+lowerseries <- meanseries - 2 * BB
 
 


### PR DESCRIPTION
## Summary
- fix the Bollinger Bands calculation in `BasicStockAnalysis.R`

## Testing
- `Rscript -e '1+1'` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68681c4adfcc832f8995065ab6b158e9